### PR TITLE
Refactor dashboard queries and API field organization

### DIFF
--- a/web/src/app/providers/AppProviders.tsx
+++ b/web/src/app/providers/AppProviders.tsx
@@ -1,15 +1,6 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { ThemeProvider } from '@/shared/ui/theme'
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 10_000,
-      refetchOnWindowFocus: false,
-    },
-  },
-})
+import { QueryProvider } from './QueryProvider'
 
 type AppProvidersProps = {
   children: ReactNode
@@ -17,8 +8,8 @@ type AppProvidersProps = {
 
 export function AppProviders({ children }: AppProvidersProps) {
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryProvider>
       <ThemeProvider>{children}</ThemeProvider>
-    </QueryClientProvider>
+    </QueryProvider>
   )
 }

--- a/web/src/app/providers/QueryProvider.tsx
+++ b/web/src/app/providers/QueryProvider.tsx
@@ -1,0 +1,11 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { queryClient } from '@/shared/api'
+
+type QueryProviderProps = {
+  children: ReactNode
+}
+
+export function QueryProvider({ children }: QueryProviderProps) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}

--- a/web/src/pages/dashboard/api/dashboard-queries.ts
+++ b/web/src/pages/dashboard/api/dashboard-queries.ts
@@ -1,0 +1,23 @@
+import { queryOptions } from '@tanstack/react-query'
+import { dashboardApi } from '@/shared/api'
+import { fetchDashboardConfig } from '../model/dashboard'
+
+export const dashboardQueries = {
+  all: () => ['dashboard'] as const,
+  config: () =>
+    queryOptions({
+      queryKey: [...dashboardQueries.all(), 'config'] as const,
+      queryFn: fetchDashboardConfig,
+    }),
+  status: () =>
+    queryOptions({
+      queryKey: [...dashboardQueries.all(), 'status'] as const,
+      queryFn: dashboardApi.getStatus,
+      refetchInterval: 30000,
+    }),
+  auditLogs: () =>
+    queryOptions({
+      queryKey: [...dashboardQueries.all(), 'auditLogs'] as const,
+      queryFn: dashboardApi.listAuditLogs,
+    }),
+}

--- a/web/src/pages/dashboard/model/dashboard.ts
+++ b/web/src/pages/dashboard/model/dashboard.ts
@@ -17,8 +17,6 @@ export type ServiceFormData = Pick<
 type PendingService = ServiceFormData & Partial<Pick<Service, 'id' | 'categoryId' | 'order'>>
 
 export type ServiceViewModel = (Service | PendingService) & {
-  logoUrl?: string
-  serviceUrl?: string
   sortOrder?: number
 }
 

--- a/web/src/pages/dashboard/model/use-dashboard.ts
+++ b/web/src/pages/dashboard/model/use-dashboard.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'react-toastify'
-import { dashboardApi, subscribeStatus } from '@/shared/api'
+import { subscribeStatus } from '@/shared/api'
+import { dashboardQueries } from '../api/dashboard-queries'
 import {
   exportConfig as exportConfigToFile,
   importConfig as importConfigFromFile,
@@ -14,7 +15,7 @@ import type {
   ServiceStatusMap,
   ServiceViewModel,
 } from './dashboard'
-import { fetchDashboardConfig, saveDashboardConfig } from './dashboard'
+import { saveDashboardConfig } from './dashboard'
 
 export type EditingService = {
   service: ServiceViewModel
@@ -31,12 +32,6 @@ export type EditingCategory = {
   categoryIndex: number
 }
 
-const queryKeys = {
-  config: ['dashboardConfig'] as const,
-  status: ['serviceStatus'] as const,
-  auditLogs: ['auditLogs'] as const,
-}
-
 export function useDashboard() {
   const queryClient = useQueryClient()
   const [isAddingCategory, setIsAddingCategory] = useState(false)
@@ -46,25 +41,19 @@ export function useDashboard() {
   const [editingCategory, setEditingCategory] = useState<EditingCategory | null>(null)
   const [auditLogsOpen, setAuditLogsOpen] = useState(false)
 
-  const configQuery = useQuery({
-    queryKey: queryKeys.config,
-    queryFn: fetchDashboardConfig,
-  })
+  const configQuery = useQuery(dashboardQueries.config())
   const config = configQuery.data ?? null
   const loading = configQuery.isLoading
   const error = configQuery.error ? '配置加载失败' : null
 
   const statusQuery = useQuery({
-    queryKey: queryKeys.status,
-    queryFn: dashboardApi.getStatus,
+    ...dashboardQueries.status(),
     enabled: Boolean(config),
-    refetchInterval: 30000,
   })
   const serviceStatus = (statusQuery.data ?? {}) as ServiceStatusMap
 
   const auditLogsQuery = useQuery({
-    queryKey: queryKeys.auditLogs,
-    queryFn: dashboardApi.listAuditLogs,
+    ...dashboardQueries.auditLogs(),
     enabled: auditLogsOpen,
   })
 
@@ -83,7 +72,7 @@ export function useDashboard() {
         if (import.meta.env.VITE_DEBUG_STATUS === '1') {
           console.debug('[status] stream event', status)
         }
-        queryClient.setQueryData(queryKeys.status, status)
+        queryClient.setQueryData(dashboardQueries.status().queryKey, status)
       },
       (error) => {
         console.warn('服务状态实时流失败，使用 React Query 轮询:', error)
@@ -98,7 +87,7 @@ export function useDashboard() {
   }, [config, queryClient])
 
   const setConfig = (updater: (prevConfig: DashboardViewModel | null) => DashboardViewModel | null) => {
-    queryClient.setQueryData<DashboardViewModel>(queryKeys.config, (current) => {
+    queryClient.setQueryData<DashboardViewModel>(dashboardQueries.config().queryKey, (current) => {
       const next = updater(current ?? null)
       return next ?? current
     })
@@ -108,10 +97,10 @@ export function useDashboard() {
     mutationFn: ({ nextConfig, options }: { nextConfig: DashboardViewModel; options: SaveConfigOptions; successMessage: string }) =>
       saveDashboardConfig(nextConfig, options),
     onSuccess: async (_result, variables) => {
-      await queryClient.invalidateQueries({ queryKey: queryKeys.config })
+      await queryClient.invalidateQueries({ queryKey: dashboardQueries.config().queryKey })
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.status }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.auditLogs }),
+        queryClient.invalidateQueries({ queryKey: dashboardQueries.status().queryKey }),
+        queryClient.invalidateQueries({ queryKey: dashboardQueries.auditLogs().queryKey }),
       ])
       toast.success(variables.successMessage, {
         autoClose: 1000,
@@ -342,10 +331,10 @@ export function useDashboard() {
     try {
       const importedConfig = await importConfigFromFile(file)
       if (importedConfig) {
-        queryClient.setQueryData(queryKeys.config, importedConfig)
+        queryClient.setQueryData(dashboardQueries.config().queryKey, importedConfig)
         await Promise.all([
-          queryClient.invalidateQueries({ queryKey: queryKeys.status }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.auditLogs }),
+          queryClient.invalidateQueries({ queryKey: dashboardQueries.status().queryKey }),
+          queryClient.invalidateQueries({ queryKey: dashboardQueries.auditLogs().queryKey }),
         ])
         document.title = importedConfig.title || 'HomeLab Dashboard'
         toast.success('配置已导入')

--- a/web/src/shared/api/dashboard.ts
+++ b/web/src/shared/api/dashboard.ts
@@ -6,7 +6,7 @@ import type {
   CategoryUpdateRequest,
   DashboardSettings,
   GetStatusResponse,
-  ImportConfigData,
+  ImportConfigRequest,
   Service,
   ServiceCreateRequest,
   ServiceListResponse,
@@ -14,29 +14,63 @@ import type {
 } from './contract'
 import { apiClient } from './http'
 
-type CategoryPayloadSource = CategoryCreateRequest & Partial<Pick<Category, 'id' | 'order'>>
-type ServicePayloadSource = Pick<
+const DEFAULT_CATEGORY_ICON = 'fa-solid fa-folder'
+
+type CategoryWriteSource = CategoryCreateRequest & Partial<Pick<Category, 'id' | 'order'>>
+type ServiceWriteSource = Pick<
   ServiceCreateRequest,
   'name' | 'logo' | 'url' | 'target' | 'monitorEnabled' | 'monitorUrl'
 > &
-  Partial<Pick<Service, 'id' | 'categoryId' | 'order'>> & {
-    logoUrl?: string
-    serviceUrl?: string
-  }
+  Partial<Pick<Service, 'id' | 'categoryId' | 'order'>>
 type ServiceTarget = NonNullable<ServiceCreateRequest['target']>
-type ImportConfigRequest = ImportConfigData['body']
 
-function toServiceTarget(target: ServicePayloadSource['target']): ServiceTarget {
+function resourceUrl(resource: 'categories' | 'services', id: CategoryWriteSource['id'] | ServiceWriteSource['id']): string {
+  return `/api/v1/${resource}/${encodeURIComponent(String(id))}`
+}
+
+async function listResponseData<T extends { data: unknown }>(url: string): Promise<T['data']> {
+  const response = await apiClient.get<T>(url)
+  return response.data
+}
+
+function toServiceTarget(target: ServiceWriteSource['target']): ServiceTarget {
   return target === '_self' ? '_self' : '_blank'
 }
 
-function toServicePayload(service: ServicePayloadSource): ServiceUpdateRequest {
+function toCreateCategoryRequest(category: CategoryWriteSource): CategoryCreateRequest {
+  return {
+    name: category.name,
+    icon: category.icon ?? DEFAULT_CATEGORY_ICON,
+  }
+}
+
+function toUpdateCategoryRequest(category: CategoryWriteSource): CategoryUpdateRequest {
+  return {
+    name: category.name,
+    icon: category.icon,
+    order: category.order,
+  }
+}
+
+function toCreateServiceRequest(categoryId: Category['id'], service: ServiceWriteSource): ServiceCreateRequest {
+  return {
+    categoryId: Number(categoryId),
+    name: service.name,
+    logo: service.logo,
+    url: service.url,
+    target: toServiceTarget(service.target),
+    monitorUrl: service.monitorUrl,
+    monitorEnabled: service.monitorEnabled,
+  }
+}
+
+function toUpdateServiceRequest(service: ServiceWriteSource): ServiceUpdateRequest {
   return {
     categoryId: service.categoryId == null ? undefined : Number(service.categoryId),
     order: service.order,
     name: service.name,
-    logo: service.logo ?? service.logoUrl ?? '',
-    url: service.url ?? service.serviceUrl ?? '',
+    logo: service.logo,
+    url: service.url,
     target: service.target == null ? undefined : toServiceTarget(service.target),
     monitorUrl: service.monitorUrl,
     monitorEnabled: service.monitorEnabled,
@@ -45,46 +79,20 @@ function toServicePayload(service: ServicePayloadSource): ServiceUpdateRequest {
 
 export const dashboardApi = {
   getSettings: () => apiClient.get<DashboardSettings>('/api/v1/dashboard'),
-  listCategories: async () => {
-    const response = await apiClient.get<CategoryListResponse>('/api/v1/categories')
-    return response.data
-  },
-  listServices: async () => {
-    const response = await apiClient.get<ServiceListResponse>('/api/v1/services')
-    return response.data
-  },
-  createCategory: (category: CategoryPayloadSource) =>
-    apiClient.post<Category>('/api/v1/categories', {
-      name: category.name,
-      icon: category.icon ?? 'fa-solid fa-folder',
-    } satisfies CategoryCreateRequest),
-  updateCategory: (category: CategoryPayloadSource) =>
-    apiClient.patch<Category>(`/api/v1/categories/${encodeURIComponent(String(category.id))}`, {
-      name: category.name,
-      icon: category.icon,
-      order: category.order,
-    } satisfies CategoryUpdateRequest),
-  deleteCategory: (category: CategoryPayloadSource) =>
-    apiClient.delete<null>(`/api/v1/categories/${encodeURIComponent(String(category.id))}`),
-  createService: (categoryId: Category['id'], service: ServicePayloadSource) =>
-    apiClient.post<Service>('/api/v1/services', {
-      categoryId: Number(categoryId),
-      name: service.name,
-      logo: service.logo ?? service.logoUrl ?? '',
-      url: service.url ?? service.serviceUrl ?? '',
-      target: toServiceTarget(service.target),
-      monitorUrl: service.monitorUrl,
-      monitorEnabled: service.monitorEnabled,
-    } satisfies ServiceCreateRequest),
-  updateService: (service: ServicePayloadSource) =>
-    apiClient.patch<Service>(`/api/v1/services/${encodeURIComponent(String(service.id))}`, toServicePayload(service)),
-  deleteService: (service: ServicePayloadSource) =>
-    apiClient.delete<null>(`/api/v1/services/${encodeURIComponent(String(service.id))}`),
+  listCategories: () => listResponseData<CategoryListResponse>('/api/v1/categories'),
+  listServices: () => listResponseData<ServiceListResponse>('/api/v1/services'),
+  createCategory: (category: CategoryWriteSource) =>
+    apiClient.post<Category>('/api/v1/categories', toCreateCategoryRequest(category)),
+  updateCategory: (category: CategoryWriteSource) =>
+    apiClient.patch<Category>(resourceUrl('categories', category.id), toUpdateCategoryRequest(category)),
+  deleteCategory: (category: CategoryWriteSource) => apiClient.delete<null>(resourceUrl('categories', category.id)),
+  createService: (categoryId: Category['id'], service: ServiceWriteSource) =>
+    apiClient.post<Service>('/api/v1/services', toCreateServiceRequest(categoryId, service)),
+  updateService: (service: ServiceWriteSource) =>
+    apiClient.patch<Service>(resourceUrl('services', service.id), toUpdateServiceRequest(service)),
+  deleteService: (service: ServiceWriteSource) => apiClient.delete<null>(resourceUrl('services', service.id)),
   getStatus: () => apiClient.get<GetStatusResponse>('/api/v1/status'),
-  listAuditLogs: async () => {
-    const response = await apiClient.get<AuditLogListResponse>('/api/v1/audit-logs?limit=50')
-    return response.data
-  },
+  listAuditLogs: () => listResponseData<AuditLogListResponse>('/api/v1/audit-logs?limit=50'),
   exportConfig: () => apiClient.blob({ url: '/api/v1/export', method: 'GET' }),
   importConfig: (config: ImportConfigRequest) => apiClient.put('/api/v1/import', config),
 }

--- a/web/src/shared/api/index.ts
+++ b/web/src/shared/api/index.ts
@@ -1,3 +1,4 @@
 export { dashboardApi, subscribeStatus } from './dashboard'
 export { ApiError, HttpClient, apiClient, type HttpRequestConfig } from './http'
+export { queryClient } from './query-client'
 export type * from './contract'

--- a/web/src/shared/api/query-client.ts
+++ b/web/src/shared/api/query-client.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 10_000,
+      refetchOnWindowFocus: false,
+    },
+  },
+})


### PR DESCRIPTION
需求：按 FSD 与 TanStack Query 组织 dashboard 数据获取，并去掉 shared API 中不必要的旧字段兼容。

实现：新增 dashboard query factory 统一 queryOptions；useDashboard 复用统一 query key；API wrapper 拆出请求 payload 构造，并统一服务字段为 logo/url。

验证：npm run typecheck；npm test；npm run build；CI=1 npm run test:e2e。