### PR TITLE
fix: 优化服务状态流与状态灯聚合

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -492,6 +493,11 @@ func getV1StatusStream(w http.ResponseWriter, r *http.Request, st *store.Store) 
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
+	if err := writeStatusStreamReady(w); err != nil {
+		log.Printf("[status] v1 stream ready write failed: %v", err)
+		return
+	}
+	flusher.Flush()
 
 	writeSnapshot := func() bool {
 		results, err := loadV1StatusResults(r.Context(), st)
@@ -525,6 +531,11 @@ func getV1StatusStream(w http.ResponseWriter, r *http.Request, st *store.Store) 
 	}
 }
 
+func writeStatusStreamReady(w io.Writer) error {
+	_, err := io.WriteString(w, ": connected\n\n")
+	return err
+}
+
 func loadV1StatusResults(ctx context.Context, st *store.Store) (map[string]monitor.Result, error) {
 	services, err := st.ListServices(ctx)
 	if err != nil {
@@ -533,17 +544,31 @@ func loadV1StatusResults(ctx context.Context, st *store.Store) (map[string]monit
 
 	checker := monitor.NewChecker(3 * time.Second)
 	results := map[string]monitor.Result{}
+	var mutex sync.Mutex
+	var checks sync.WaitGroup
+
 	for _, service := range services {
 		if !service.MonitorEnabled {
 			continue
 		}
-		monitorURL := service.MonitorURL
-		if monitorURL == "" {
-			monitorURL = service.URL
-		}
-		result := checker.Check(ctx, service.Name, monitorURL)
-		results[strconv.FormatInt(service.ID, 10)] = result
+		service := service
+		checks.Add(1)
+		go func() {
+			defer checks.Done()
+
+			monitorURL := service.MonitorURL
+			if monitorURL == "" {
+				monitorURL = service.URL
+			}
+			result := checker.Check(ctx, service.Name, monitorURL)
+
+			mutex.Lock()
+			results[strconv.FormatInt(service.ID, 10)] = result
+			mutex.Unlock()
+		}()
 	}
+	checks.Wait()
+
 	return results, nil
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/zouzonghua/homelab-dashboard/internal/config"
 	"github.com/zouzonghua/homelab-dashboard/internal/store"
@@ -309,6 +310,46 @@ func TestGetV1StatusReturnsResultsKeyedByServiceID(t *testing.T) {
 	}
 }
 
+func TestGetV1StatusChecksServicesConcurrently(t *testing.T) {
+	monitored := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer monitored.Close()
+
+	seed := apiSampleConfig("v1 status concurrent")
+	seed.Items[0].List = []config.Service{
+		{Name: "One", URL: monitored.URL, Target: "_blank", MonitorEnabled: true},
+		{Name: "Two", URL: monitored.URL, Target: "_blank", MonitorEnabled: true},
+		{Name: "Three", URL: monitored.URL, Target: "_blank", MonitorEnabled: true},
+	}
+	handler, cleanup := newTestHandler(t, seed)
+	defer cleanup()
+
+	startedAt := time.Now()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	elapsed := time.Since(startedAt)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/status status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if elapsed > 600*time.Millisecond {
+		t.Fatalf("status checks took %s, want concurrent checks below 600ms", elapsed)
+	}
+
+	var got map[string]struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("status result count = %d, want 3: %#v", len(got), got)
+	}
+}
+
 func TestGetV1StatusStreamEmitsResultsKeyedByServiceID(t *testing.T) {
 	monitored := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
@@ -332,26 +373,67 @@ func TestGetV1StatusStreamEmitsResultsKeyedByServiceID(t *testing.T) {
 	defer resp.Body.Close()
 
 	scanner := bufio.NewScanner(resp.Body)
-	var lines []string
+	var dataLine string
+	inStatusEvent := false
 	for scanner.Scan() {
 		line := scanner.Text()
-		if line == "" {
+		if line == "event: status" {
+			inStatusEvent = true
+			continue
+		}
+		if inStatusEvent && strings.HasPrefix(line, "data: ") {
+			dataLine = strings.TrimPrefix(line, "data: ")
 			break
 		}
-		lines = append(lines, line)
 	}
 	if err := scanner.Err(); err != nil {
 		t.Fatalf("read stream: %v", err)
+	}
+	if dataLine == "" {
+		t.Fatal("stream did not emit status data")
 	}
 
 	var got map[string]struct {
 		Status string `json:"status"`
 	}
-	if err := json.Unmarshal([]byte(strings.TrimPrefix(lines[1], "data: ")), &got); err != nil {
+	if err := json.Unmarshal([]byte(dataLine), &got); err != nil {
 		t.Fatalf("decode status event: %v", err)
 	}
 	if got[fmt.Sprint(serviceID)].Status != "up" {
 		t.Fatalf("stream status = %#v, want service id %d up", got, serviceID)
+	}
+}
+
+func TestGetV1StatusStreamFlushesBeforeStatusChecks(t *testing.T) {
+	monitored := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer monitored.Close()
+
+	seed := apiSampleConfig("v1 status stream fast open")
+	seed.Items[0].List[0].MonitorEnabled = true
+	seed.Items[0].List[0].MonitorURL = monitored.URL
+	handler, cleanup := newTestHandler(t, seed)
+	defer cleanup()
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	client := server.Client()
+	client.Timeout = 200 * time.Millisecond
+	resp, err := client.Get(server.URL + "/api/v1/status/stream")
+	if err != nil {
+		t.Fatalf("GET /api/v1/status/stream returned before status checks finish: %v", err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	if !scanner.Scan() {
+		t.Fatalf("read initial stream line: %v", scanner.Err())
+	}
+	if got, want := scanner.Text(), ": connected"; got != want {
+		t.Fatalf("initial stream line = %q, want %q", got, want)
 	}
 }
 

--- a/web/e2e/dashboard.spec.js
+++ b/web/e2e/dashboard.spec.js
@@ -1,12 +1,20 @@
 import { expect, test } from '@playwright/test'
 
 test('loads dashboard and persists a new service after reload', async ({ page }) => {
+  const statusRequests = []
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/v1/status') {
+      statusRequests.push(request)
+    }
+  })
+
   await page.goto('/')
 
   await expect(page.getByRole('heading', { name: /homelab dashboard/i })).toBeVisible()
   await expect(page.getByText('Jellyfin')).toBeVisible()
   await expect(page.getByText('HOMELAB', { exact: true })).toHaveCount(0)
   await expect(page.locator('.chassis-header__leds .status-port')).toHaveCount(4)
+  expect(statusRequests).toHaveLength(0)
 
   await page.getByRole('button', { name: 'Enter edit mode' }).click()
   await page.getByRole('button', { name: 'Add service to Media' }).click()
@@ -31,4 +39,5 @@ test('loads dashboard and persists a new service after reload', async ({ page })
   await expect(page.getByRole('button', { name: 'Visit E2E Service' })).toBeVisible()
   await expect(page.getByLabel('E2E Service service status up')).toBeVisible()
   await expect(page.getByRole('button', { name: 'Visit E2E Service' }).getByText(/\d+ms/)).toBeVisible()
+  expect(statusRequests).toHaveLength(0)
 })

--- a/web/src/pages/dashboard/model/use-dashboard.ts
+++ b/web/src/pages/dashboard/model/use-dashboard.ts
@@ -45,10 +45,11 @@ export function useDashboard() {
   const config = configQuery.data ?? null
   const loading = configQuery.isLoading
   const error = configQuery.error ? 'Failed to load config' : null
+  const [statusPollingEnabled, setStatusPollingEnabled] = useState(false)
 
   const statusQuery = useQuery({
     ...dashboardQueries.status(),
-    enabled: Boolean(config),
+    enabled: Boolean(config) && statusPollingEnabled,
   })
   const serviceStatus = (statusQuery.data ?? {}) as ServiceStatusMap
 
@@ -69,6 +70,7 @@ export function useDashboard() {
 
     unsubscribe = subscribeStatus(
       (status) => {
+        setStatusPollingEnabled(false)
         if (import.meta.env.VITE_DEBUG_STATUS === '1') {
           console.debug('[status] stream event', status)
         }
@@ -78,8 +80,13 @@ export function useDashboard() {
         console.warn('Live status stream failed, falling back to React Query polling:', error)
         unsubscribe?.()
         unsubscribe = null
+        setStatusPollingEnabled(true)
       },
     )
+
+    if (!unsubscribe) {
+      setStatusPollingEnabled(true)
+    }
 
     return () => {
       unsubscribe?.()

--- a/web/src/pages/dashboard/ui/Header.test.tsx
+++ b/web/src/pages/dashboard/ui/Header.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { getCategoryLed } from './Header'
+import type { CategoryWithServices, ServiceStatusMap } from '../model/dashboard'
+
+const category = (services: CategoryWithServices['list']): CategoryWithServices => ({
+  id: 1,
+  name: 'Media',
+  icon: 'fa-solid fa-film',
+  order: 0,
+  list: services,
+})
+
+const service = (id: number): CategoryWithServices['list'][number] => ({
+  id,
+  categoryId: 1,
+  order: id,
+  name: `Service ${id}`,
+  logo: '',
+  url: `https://service-${id}.example`,
+  target: '_blank',
+  monitorEnabled: true,
+})
+
+const status = (entries: Record<string, 'up' | 'down'>): ServiceStatusMap =>
+  Object.fromEntries(
+    Object.entries(entries).map(([id, value]) => [
+      id,
+      {
+        name: `Service ${id}`,
+        status: value,
+        method: 'GET',
+        code: value === 'up' ? 200 : 500,
+        responseTimeMs: 12,
+        checkedAt: new Date().toISOString(),
+      },
+    ]),
+  )
+
+describe('getCategoryLed', () => {
+  it('uses green when every monitored service is up', () => {
+    const led = getCategoryLed(category([service(1), service(2)]), status({ 1: 'up', 2: 'up' }))
+
+    expect(led.className).toBe('status-online')
+  })
+
+  it('uses yellow when only part of a category is down', () => {
+    const led = getCategoryLed(category([service(1), service(2)]), status({ 1: 'up', 2: 'down' }))
+
+    expect(led.className).toBe('status-port-warning')
+  })
+
+  it('uses red when every monitored service is down', () => {
+    const led = getCategoryLed(category([service(1), service(2)]), status({ 1: 'down', 2: 'down' }))
+
+    expect(led.className).toBe('status-port-down')
+  })
+})

--- a/web/src/pages/dashboard/ui/Header.tsx
+++ b/web/src/pages/dashboard/ui/Header.tsx
@@ -33,7 +33,7 @@ const getStableHash = (value?: string) =>
     return nextHash >>> 0
   }, 0)
 
-const getCategoryLed = (category: CategoryWithServices, serviceStatus: ServiceStatusMap) => {
+export const getCategoryLed = (category: CategoryWithServices, serviceStatus: ServiceStatusMap) => {
   const monitored = category.list.filter((service) => service.monitorEnabled)
   if (monitored.length === 0) {
     return {
@@ -54,11 +54,14 @@ const getCategoryLed = (category: CategoryWithServices, serviceStatus: ServiceSt
     return nextCounts
   }, { up: 0, down: 0, pending: 0 })
 
-  const className = counts.down > 0
-    ? 'status-port-down'
-    : counts.pending > 0
-      ? 'status-port-warning'
-      : 'status-online'
+  let className = 'status-port-pending'
+  if (counts.down === monitored.length) {
+    className = 'status-port-down'
+  } else if (counts.down > 0) {
+    className = 'status-port-warning'
+  } else if (counts.up === monitored.length) {
+    className = 'status-online'
+  }
 
   return {
     className,


### PR DESCRIPTION
需求：刷新页面时避免状态接口首包等待过久，并让机箱头部状态灯区分部分异常和全部异常。

实现：前端优先使用 SSE，只有流不可用或报错时回退轮询；后端 SSE 建连后立即 flush 连接注释，并发检查服务状态；Header 聚合灯改为全通绿色、部分不通黄色、全不通红。

验证：git diff --check；go test ./cmd/... ./internal/...；npm run typecheck；npm test；npm run build；CI=1 npm run test:e2e。